### PR TITLE
Implement simple Azure OpenAI chatbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# azure-openai-chatbot
-This chatbot to use SSO to connect to your Azure OpenAI models to allow the enterprise user to use.
+# Azure OpenAI Chatbot
+
+This project provides a simple ChatGPT‑like web interface that authenticates users with Azure AD (SSO) and forwards prompts to a model hosted on Azure OpenAI. Chat history is stored in the browser session for the signed‑in user only.
+
+## Features
+
+* **Azure AD SSO** using the [MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-python) library.
+* **Connect to Azure OpenAI** by specifying your endpoint and deployment name.
+* **Chat history stored locally** via `sessionStorage` in the browser.
+
+## Setup
+
+1. Create an Azure AD application registration and configure redirect URIs.
+2. Deploy a model using Azure OpenAI and note the endpoint and deployment name.
+3. Set the following environment variables before starting the app:
+
+```
+FLASK_SECRET=replace-with-random-string
+AZURE_CLIENT_ID=<application-client-id>
+AZURE_CLIENT_SECRET=<application-client-secret>
+AZURE_TENANT_ID=<tenant-id>
+AZURE_SCOPE=<scope-for-token>  # usually "api://<app-id>/.default"
+OPENAI_ENDPOINT=<https://your-openai-resource.openai.azure.com/>
+OPENAI_DEPLOYMENT=<name-of-your-deployment>
+OPENAI_API_KEY=<api-key-for-openai-resource>
+OPENAI_API_VERSION=<api-version>
+# Optional: override defaults
+OPENAI_API_TYPE=azure
+FLASK_HOST=127.0.0.1
+FLASK_PORT=5000
+FLASK_DEBUG=true
+```
+
+Install dependencies and run the server:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Navigate to `http://localhost:5000` and sign in with your Azure AD credentials.
+
+## Notes
+
+This is a basic sample intended for demonstration purposes. Production deployments should use HTTPS, proper session storage, CSRF protection and improved error handling.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,98 @@
+import os
+from flask import Flask, session, redirect, url_for, render_template, request, jsonify
+from msal import ConfidentialClientApplication
+import openai
+
+app = Flask(__name__)
+app.secret_key = os.environ.get("FLASK_SECRET")
+
+# Azure AD / MSAL config
+CLIENT_ID = os.environ.get("AZURE_CLIENT_ID")
+CLIENT_SECRET = os.environ.get("AZURE_CLIENT_SECRET")
+TENANT_ID = os.environ.get("AZURE_TENANT_ID")
+AUTHORITY = (
+    f"https://login.microsoftonline.com/{TENANT_ID}" if TENANT_ID else None
+)
+SCOPE = [os.environ.get("AZURE_SCOPE")]
+
+# Azure OpenAI config
+OPENAI_ENDPOINT = os.environ.get("OPENAI_ENDPOINT")
+OPENAI_DEPLOYMENT = os.environ.get("OPENAI_DEPLOYMENT")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+OPENAI_API_VERSION = os.environ.get("OPENAI_API_VERSION")
+OPENAI_API_TYPE = os.environ.get("OPENAI_API_TYPE", "azure")
+
+if OPENAI_ENDPOINT:
+    openai.api_base = OPENAI_ENDPOINT
+if OPENAI_API_KEY:
+    openai.api_key = OPENAI_API_KEY
+if OPENAI_API_VERSION:
+    openai.api_version = OPENAI_API_VERSION
+openai.api_type = OPENAI_API_TYPE
+
+@app.route('/')
+def index():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    return render_template('index.html', user=session.get('user'))
+
+@app.route('/login')
+def login():
+    if not all([CLIENT_ID, CLIENT_SECRET, TENANT_ID]):
+        return "Missing Azure AD configuration", 500
+    redirect_uri = url_for('authorized', _external=True)
+    cca = ConfidentialClientApplication(
+        CLIENT_ID, authority=AUTHORITY, client_credential=CLIENT_SECRET
+    )
+    auth_url = cca.get_authorization_request_url(SCOPE, redirect_uri=redirect_uri)
+    return redirect(auth_url)
+
+@app.route('/authorized')
+def authorized():
+    if 'code' not in request.args:
+        return redirect(url_for('index'))
+    code = request.args['code']
+    cca = ConfidentialClientApplication(
+        CLIENT_ID, authority=AUTHORITY, client_credential=CLIENT_SECRET
+    )
+    redirect_uri = url_for('authorized', _external=True)
+    result = cca.acquire_token_by_authorization_code(code, scopes=SCOPE, redirect_uri=redirect_uri)
+    if "id_token_claims" in result:
+        session['user'] = result['id_token_claims']
+        session['access_token'] = result['access_token']
+    else:
+        return f"Login failure: {result.get('error_description')}", 500
+    return redirect(url_for('index'))
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(
+        f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/logout?post_logout_redirect_uri=" + url_for('index', _external=True)
+    )
+
+@app.route('/api/chat', methods=['POST'])
+def chat():
+    if 'user' not in session:
+        return jsonify({'error': 'unauthorized'}), 401
+    data = request.json
+    message = data.get('message')
+    if not message:
+        return jsonify({'error': 'no message'}), 400
+    if not (OPENAI_ENDPOINT and OPENAI_DEPLOYMENT):
+        return jsonify({'error': 'OpenAI not configured'}), 500
+    try:
+        response = openai.ChatCompletion.create(
+            engine=OPENAI_DEPLOYMENT,
+            messages=[{"role": "user", "content": message}]
+        )
+        answer = response['choices'][0]['message']['content']
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    return jsonify({'answer': answer})
+
+if __name__ == '__main__':
+    debug = os.environ.get("FLASK_DEBUG", "true").lower() in ["1", "true", "yes"]
+    host = os.environ.get("FLASK_HOST", "127.0.0.1")
+    port = int(os.environ.get("FLASK_PORT", "5000"))
+    app.run(host=host, port=port, debug=debug)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+msal
+openai

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,0 +1,45 @@
+const chatWindow = document.getElementById('chat-window');
+const chatForm = document.getElementById('chat-form');
+const messageInput = document.getElementById('message');
+
+function appendMessage(role, text) {
+    const div = document.createElement('div');
+    div.className = role;
+    div.textContent = text;
+    chatWindow.appendChild(div);
+    chatWindow.scrollTop = chatWindow.scrollHeight;
+}
+
+function loadHistory() {
+    const history = JSON.parse(sessionStorage.getItem('chatHistory') || '[]');
+    history.forEach(item => appendMessage(item.role, item.text));
+}
+
+function saveMessage(role, text) {
+    const history = JSON.parse(sessionStorage.getItem('chatHistory') || '[]');
+    history.push({role, text});
+    sessionStorage.setItem('chatHistory', JSON.stringify(history));
+}
+
+chatForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const text = messageInput.value.trim();
+    if (!text) return;
+    appendMessage('user', text);
+    saveMessage('user', text);
+    messageInput.value = '';
+    const resp = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({message: text})
+    });
+    const data = await resp.json();
+    if (data.answer) {
+        appendMessage('assistant', data.answer);
+        saveMessage('assistant', data.answer);
+    } else {
+        appendMessage('error', data.error || 'Error');
+    }
+});
+
+loadHistory();

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,42 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background: #f0f0f0;
+}
+header {
+    background: #0a5aab;
+    color: #fff;
+    padding: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+#chat-window {
+    height: 70vh;
+    overflow-y: auto;
+    padding: 10px;
+    background: #fff;
+    margin: 10px;
+    border: 1px solid #ccc;
+}
+.user {
+    text-align: right;
+    color: #0a5aab;
+}
+.assistant {
+    text-align: left;
+    color: #333;
+}
+.error {
+    color: red;
+}
+#chat-form {
+    display: flex;
+    padding: 10px;
+    background: #eee;
+}
+#message {
+    flex: 1;
+    padding: 5px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Azure OpenAI Chatbot</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <header>
+        <h1>Azure OpenAI Chatbot</h1>
+        <div id="user-info">
+            Signed in as {{ user.get('name') if user else '' }} | <a href="{{ url_for('logout') }}">Logout</a>
+        </div>
+    </header>
+    <main>
+        <div id="chat-window"></div>
+        <form id="chat-form">
+            <input type="text" id="message" autocomplete="off" placeholder="Type your message..." required>
+            <button type="submit">Send</button>
+        </form>
+    </main>
+    <script src="{{ url_for('static', filename='chat.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask server with Azure AD SSO and OpenAI chat endpoint
- store chat history in browser session
- document environment variables and usage in README
- include simple frontend HTML/CSS/JS
- use environment variables for configuration

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_685ac0401ed883339e9d2c836eba18b8